### PR TITLE
feat: ajout d'un template d'issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/composant.md
+++ b/.github/ISSUE_TEMPLATE/composant.md
@@ -1,0 +1,23 @@
+---
+name: Nouveau composant
+about: Utiliser ce template pour créer un nouveau composant.
+title: "[composant] Implémentation de [COMPOSANT]"
+labels: composant
+---
+
+ETQ utilisateur/utilisatrice, je souhaite pouvoir ajouter un composant de type `[COMPOSANT]()` conforme au dsfr à mon application shiny dsfr
+
+## Critères d'acceptation des développements effectués
+
+- [ ] Une fonction implementée, documentée, testée : `[COMPOSANT]_dsfr()'
+   - [ ] Avec la documentation dans le corps de la fonction
+   - [ ] La présentation dans une vignette
+   - [ ] Des tests unitaires
+- [ ] Un exemple d'utilisation dans l'application de démonstration est disponible
+
+## Comment technique
+
+- Je crée une branche pour développer la fonctionnalité
+- Utilisation du workflow décrit dans  'dev/documentation/comment-faire-un-composant-shiny.Rmd'
+- Utiliser le flat file fourni pour développer avec {fusen}
+- J'ouvre une PR assignée à @statnmap lorsque c'est traité

--- a/dev/documentation/README.Rmd
+++ b/dev/documentation/README.Rmd
@@ -29,15 +29,15 @@ desc::desc_set("VersionDsfr" = "1.7.2")
 ```
 
 
-## Workflow a suivre avant de dev sur le projet :
+## Workflow à suivre avant de dev sur le projet :
 
-- Ajouter le template de commit :
+### Ajouter le template de commit :
 
 ```
 git config --local commit.template .github/template_commit
 ```
 
-Et suivre cette convention pour les commits et les tags :
+### Suivre cette convention pour les commits et les tags :
 
 - Un mot clé et un titre en début de message pour dire le principal objectif de ce commit.
 - Une ligne `tags` qui reprend les mots clés pour ce qui est fait dans le commit
@@ -69,17 +69,28 @@ test: pour les tests unitaires
 style : pour la mise en forme de code
 chore : tout ce qui touche au projet en lui même, ne correspond pas à un feat ou un fix
 ```
+### S'assurer d'avoir une issue à résoudre
+
+- Dans le cadre de l'ajout d'un nouveau composant, vous pouvez créer une issue avec le template d'issue "composant"
+    + Il se trouve sur GitHub à la création d'une issue, ou dans le package: ".github/ISSUE_TEMPLATE/composant.md"
+
+### Développer dans une branche
+
+- Chaque développement se fait dans une nouvelle branche
+    + Elle est nommée à partir du numéro de l'issue à traiter
+- Les développements sont intégrés à la branche principale après demande de PR de votre branche vers la branche principale
+
 
 ## Comprendre et appliquer le workflow pour développer le package
 
-Pour développer ce pakage, des choix techniques ont été adopter. Vous retrouverez les raisons [ici](explo_shiny.dsfr.md).
+Pour développer ce package, des choix techniques ont été adoptés. Vous retrouverez les raisons [ici](explo_shiny.dsfr.md).
 
 Le workflow se découpe en deux possibilités :
 
 - Les composants nécéssitant de la réactivité
 - Les composants sans réactivité
 
-Ces deux possibilités se basent sur le même principe **l'utilisation des templates html**. La trame général de ce workflow est définie dans la documentation: 
+Ces deux possibilités se basent sur le même principe : **l'utilisation des templates html**. La trame générale de ce workflow est définie dans la documentation : 
 
 - [Comment faire un composant shiny](comment-faire-un-composant-shiny.md)
 

--- a/dev/documentation/README.md
+++ b/dev/documentation/README.md
@@ -27,15 +27,13 @@ suivante :
 desc::desc_set("VersionDsfr" = "1.7.2")
 ```
 
-## Workflow a suivre avant de dev sur le projet :
+## Workflow à suivre avant de dev sur le projet :
 
--   Ajouter le template de commit :
-
-<!-- -->
+### Ajouter le template de commit :
 
     git config --local commit.template .github/template_commit
 
-Et suivre cette convention pour les commits et les tags :
+### Suivre cette convention pour les commits et les tags :
 
 -   Un mot clé et un titre en début de message pour dire le principal
     objectif de ce commit.
@@ -66,9 +64,23 @@ choix du tag majeur dans le titre du commit :
     style : pour la mise en forme de code
     chore : tout ce qui touche au projet en lui même, ne correspond pas à un feat ou un fix
 
+### S’assurer d’avoir une issue à résoudre
+
+-   Dans le cadre de l’ajout d’un nouveau composant, vous pouvez créer
+    une issue avec le template d’issue “composant”
+    -   Il se trouve sur GitHub à la création d’une issue, ou dans le
+        package: “.github/ISSUE_TEMPLATE/composant.md”
+
+### Développer dans une branche
+
+-   Chaque développement se fait dans une nouvelle branche
+    -   Elle est nommée à partir du numéro de l’issue à traiter
+-   Les développements sont intégrés à la branche principale après
+    demande de PR de votre branche vers la branche principale
+
 ## Comprendre et appliquer le workflow pour développer le package
 
-Pour développer ce pakage, des choix techniques ont été adopter. Vous
+Pour développer ce package, des choix techniques ont été adoptés. Vous
 retrouverez les raisons [ici](explo_shiny.dsfr.md).
 
 Le workflow se découpe en deux possibilités :
@@ -76,9 +88,9 @@ Le workflow se découpe en deux possibilités :
 -   Les composants nécéssitant de la réactivité
 -   Les composants sans réactivité
 
-Ces deux possibilités se basent sur le même principe **l’utilisation des
-templates html**. La trame général de ce workflow est définie dans la
-documentation:
+Ces deux possibilités se basent sur le même principe : **l’utilisation
+des templates html**. La trame générale de ce workflow est définie dans
+la documentation :
 
 -   [Comment faire un composant
     shiny](comment-faire-un-composant-shiny.md)


### PR DESCRIPTION
tags: feat, doc

Pourquoi?

- Un template commun pour l'ajout d'un composant nous permet de ne rien oublier lors du développement et de faciliter la validation

Quoi?

- Ajout d'un template GitHub
- Ajout de la doc des dev en conséquence

- Est-ce que mon code respecte les standards de qualité de mise en production de packages ?
- Est-ce que la personne qui révise à toutes les informations pour valider les fonctionnalités / résolutions de problèmes sans trop de recherches ?
- Est-ce que le client qui validera les tickets associés à les informations pour le faire sans perte de temps ?

## Issues à faire valider pour fermer : 

- [ ] issue #


## Issues traitées à garder ouvertes ou en cours : 

- [ ] issue #

## Checklist:

- [ ] Est-ce que le check du package passe en local ?
- [ ] Est-ce que le CI passe ?
- [ ] Est-ce que les fonctionnalités ajoutées / corrigées, sont documentées, testées ?
- [ ] Est-ce que les fonctionnalités ajoutées / problèmes résolus sont brièvement présentées dans le message de la MR ?
- [ ] Est-ce que les modifications sont liées à des tickets / issues que j'ai listés dans les commits et dans la MR elle-même ?
- [ ] Est-ce que les tickets sont en mode "révision" dans le Board de suivi du projet ?
- [ ] Est-ce que chaque ticket, s'il doit être fermé après acceptation de la MR contient un commentaire qui dit comment le valider ?

