### PR TITLE
fix: ajout de la lib CSS pour la fleche du modal

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -19,7 +19,7 @@ app_server <- function(input, output, session) {
     showModal_dsfr(
       ui = modalDialog_dsfr(
         tagList(
-          htmltools::div("Le corps du texte"),
+          htmltools::div("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
           actionButton_dsfr(
             inputId = "show_modal_btn",
             label = "Cliquez ici"

--- a/R/shinygouv-dependencies.R
+++ b/R/shinygouv-dependencies.R
@@ -13,7 +13,8 @@ add_dsfr_deps <- function(tag, version = get_dsfr_version()) {
     version = version,
     src = c(file = paste0("dsfr-v", version)),
     stylesheet = c(
-      "dist/dsfr.min.css"
+      "dist/dsfr.min.css",
+      "dist/utility/utility.min.css"
     ),
     script = list(
       list(type = "module", src = "dist/dsfr.module.min.js"),


### PR DESCRIPTION
+ Link dist/utility/utility.min.css

Fix affichage : 

![Screenshot 2023-06-29 at 11 13 49](https://github.com/spyrales/shinygouv/assets/17936236/80e72306-2df6-46a8-a033-11405c817d4b)

En

![Screenshot 2023-06-29 at 11 14 16](https://github.com/spyrales/shinygouv/assets/17936236/cd06191f-1242-40c2-8ed3-18dcd25b15af)
