### PR TITLE
ci: Ajout CRON pour lancer le CI une fois par mois

### DIFF
--- a/.github/workflows/cron-R-CMD-check.yaml
+++ b/.github/workflows/cron-R-CMD-check.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron:  '00 00 12 * *'
+
+name: R Check with cron once a month
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: rcmdcheck
+
+      - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
tags: ci

Pourquoi?

- Permet de lancer le CI régulièrement

Quoi?

- Ajout fichier cron-R-CMD-check.yaml

Tickets
#114

- Est-ce que mon code respecte les standards de qualité de mise en production de packages ?
- Est-ce que la personne qui révise à toutes les informations pour valider les fonctionnalités / résolutions de problèmes sans trop de recherches ?
- Est-ce que le client qui validera les tickets associés à les informations pour le faire sans perte de temps ?

## Issues à faire valider pour fermer : 

- [ ] issue #


## Issues traitées à garder ouvertes ou en cours : 

- [ ] issue #

## Checklist:

- [ ] Est-ce que le check du package passe en local ?
- [ ] Est-ce que le CI passe ?
- [ ] Est-ce que les fonctionnalités ajoutées / corrigées, sont documentées, testées ?
- [ ] Est-ce que les fonctionnalités ajoutées / problèmes résolus sont brièvement présentées dans le message de la MR ?
- [ ] Est-ce que les modifications sont liées à des tickets / issues que j'ai listés dans les commits et dans la MR elle-même ?
- [ ] Est-ce que les tickets sont en mode "révision" dans le Board de suivi du projet ?
- [ ] Est-ce que chaque ticket, s'il doit être fermé après acceptation de la MR contient un commentaire qui dit comment le valider ?

