### PR TITLE
fix: on passe l'id du modal au bouton de fermeture

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinygouv
 Title: Implement the DSFR for your shiny applications
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(
     person("Juliette", "ENGELAERE-LEFEBVRE", , "juliette.engelaere-lefebvre@developpement-durable.gouv.fr", role = c("aut", "cre")),
     person("Sébastien", "Rochette", , "sebastien@thinkr.fr", role = "aut",

--- a/inst/v1.9.3/composant/modalDialog.html
+++ b/inst/v1.9.3/composant/modalDialog.html
@@ -4,7 +4,7 @@
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="fr-modal-1">Fermer</button>
+                        <button class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="{{inputId}}">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal-1" class="fr-modal__title"><span class="fr-fi-arrow-right-line fr-fi--lg"></span>{{title}}</h1>


### PR DESCRIPTION
On ne pouvait pas fermer plusieurs modals
auparavant car tous les
boutons de fermeture avait le même id